### PR TITLE
Add functionality to see a pipeline's jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ What follows is a list of steps to help you get the command line tool up and run
 	```
 	export GITLAB_PRIVATE_TOKEN="[PRIVATE_TOKEN]"
 	```
-	
-2. In order for `GLPL` to check your project's pipelines it needs to know the project's id. 
+
+2. In order for `GLPL` to check your project's pipelines it needs to know the project's id.
 
 	Look at [this example](https://i.imgur.com/R6zQ1Es.png) to find your project ID and then export an environment variable named `GLPL_PROJECT_IDS` with the following pattern:
 
 	```
 	export GLPL_PROJECT_IDS="[PROJECT1_NAME]:[PROJECT1_ID],[PROJECT2_NAME]:[PROJECT2_ID],..."
 	```
-	
+
 	Example:
-	
+
 	```
 	export GLPL_PROJECT_IDS="glpl:8283313,migration:4467622"
 	```
@@ -39,9 +39,9 @@ Here are the commands you need to run in order to execute multiple functions usi
 	```
 	glpl [PROJECT_NAME]
 	```
-	
+
 * Listing pipeline jobs
 
 	```
-	glpl [PROJECT_NAME] jobs [PIPELINE_ID]
-	``` 
+	glpl [PROJECT_NAME] -p [PIPELINE_ID]
+	```

--- a/bin/glpl
+++ b/bin/glpl
@@ -13,18 +13,31 @@ if ARGV.length == 0 then
   exit
 end
 
-match = /#{ARGV[1]}:(?<id>[0-9]+)/.match(`echo $GLPL_PROJECT_IDS`)
+match = /#{ARGV[0]}:(?<id>[0-9]+)/.match(`echo $GLPL_PROJECT_IDS`)
 if match == nil then
-  puts "Project ID is not defined for #{ARGV[1]}. Please update $GLPL_PROJECT_IDS."
+  puts "Project ID is not defined for #{ARGV[0]}. Please update $GLPL_PROJECT_IDS."
   exit
 end
 project_id = match.captures[0]
 
 glpl = GLPL.new(private_token)
-for pipeline in glpl.pipelines(project_id) do
-  printf("%s %s %s\n",
-    pipeline.id.to_s.ljust(10),
-    pipeline.ref.ljust(60),
-    pipeline.status.ljust(10)
-  )
+
+if ARGV[1] == "jobs" then
+  pipeline_id = ARGV[2]
+
+  for job in glpl.jobs(project_id, pipeline_id) do
+    printf("%s %s %s\n",
+      job.id.to_s.ljust(10),
+      job.name.ljust(60),
+      job.status.ljust(10)
+    )
+  end
+else
+  for pipeline in glpl.pipelines(project_id) do
+    printf("%s %s %s\n",
+      pipeline.id.to_s.ljust(10),
+      pipeline.ref.ljust(60),
+      pipeline.status.ljust(10)
+    )
+  end
 end

--- a/bin/glpl
+++ b/bin/glpl
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'optparse'
 require 'glpl'
 
 private_token = `echo $GITLAB_PRIVATE_TOKEN`.strip()
@@ -20,24 +21,32 @@ if match == nil then
 end
 project_id = match.captures[0]
 
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: glpl [PROJECT_NAME] [options]"
+
+  opts.on("-p", "--pipeline ID", Integer, "Pipeline ID") do |pipeline_id|
+    options[:pipeline_id] = pipeline_id
+  end
+end.parse!
+
 glpl = GLPL.new(private_token)
 
-if ARGV[1] == "jobs" then
-  pipeline_id = ARGV[2]
-
-  for job in glpl.jobs(project_id, pipeline_id) do
+if options.key?(:pipeline_id) then
+  for job in glpl.jobs(project_id, options[:pipeline_id]) do
     printf("%s %s %s\n",
       job.id.to_s.ljust(10),
       job.name.ljust(60),
       job.status.ljust(10)
     )
   end
-else
-  for pipeline in glpl.pipelines(project_id) do
-    printf("%s %s %s\n",
-      pipeline.id.to_s.ljust(10),
-      pipeline.ref.ljust(60),
-      pipeline.status.ljust(10)
-    )
-  end
+  exit
+end
+
+for pipeline in glpl.pipelines(project_id) do
+  printf("%s %s %s\n",
+    pipeline.id.to_s.ljust(10),
+    pipeline.ref.ljust(60),
+    pipeline.status.ljust(10)
+  )
 end

--- a/glpl.gemspec
+++ b/glpl.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.description = "Gitlab Pipelines on your command line."
   spec.authors     = ["Dino"]
   spec.email       = 'dinojoaocosta@gmail.com'
-  spec.files       = ["lib/glpl.rb", "lib/glpl/pipeline.rb"]
+  spec.files       = ["lib/glpl.rb"] + Dir["lib/glpl/*.rb"]
   spec.license     = 'MIT'
   spec.executables << "glpl"
 end

--- a/glpl.gemspec
+++ b/glpl.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'glpl'
-  spec.version     = '0.0.0'
+  spec.version     = '0.0.1'
   spec.date        = Time.now.strftime("%Y-%m-%d")
   spec.summary     = "Gitlab Pipelines on your command line."
   spec.description = "Gitlab Pipelines on your command line."

--- a/lib/glpl.rb
+++ b/lib/glpl.rb
@@ -15,12 +15,19 @@ class GLPL
     @private_token = private_token
     @api_url = "https://gitlab.com/api/v4/projects"
   end
-
-  # Prints the pipelines status for a given project.
+  # List recent pipelines for a given project.
   # Params:
   # +project_id+:: +String+ which contains the Gitlab's project id.
   def pipelines(project_id)
     request("/#{project_id}/pipelines", :get).map { |data| GLPL::Pipeline.new(data) }
+  end
+
+  # List jobs for a given project's pipeline.
+  # Params:
+  # +project_id+:: +String+ Gitlab's project ID.
+  # +pipeline_id+:: +String+ The pipeline's ID.
+  def jobs(project_id, pipeline_id)
+    request("/#{project_id}/pipelines/#{pipeline_id}/jobs", :get).map { |data| GLPL::Job.new(data) }
   end
 
   # Makes an HTTP Requests to Gitlab's API and returns the response as JSON.
@@ -43,3 +50,4 @@ class GLPL
 end
 
 require 'glpl/pipeline'
+require 'glpl/job'

--- a/lib/glpl/job.rb
+++ b/lib/glpl/job.rb
@@ -1,0 +1,15 @@
+class GLPL::Job
+
+  attr_reader :id, :status, :stage, :name, :ref, :created_at, :username
+
+  def initialize(job_data)
+    @id         = job_data["id"]
+    @status     = job_data["status"]
+    @stage      = job_data["stage"]
+    @name       = job_data["name"]
+    @ref        = job_data["ref"]
+    @created_at = job_data["created_at"]
+    @username   = job_data["username"]
+  end
+
+end


### PR DESCRIPTION
This Merge Requests updates both the codebase and the binary tool in order to be able to check the jobs for a given pipeline.

Here are the list of major changes:
* Create `GLPL::Job` class
* Create `GLPL.jobs` method
* Update binary to enable checking of a given pipeline's jobs with:
```shell
$ glpl [PROJECT_NAME] -p [PIPELINE_ID]
```