### PR TITLE
Add ability to retry pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,9 @@ Here are the commands you need to run in order to execute multiple functions usi
 	```
 	glpl [PROJECT_NAME] -p [PIPELINE_ID]
 	```
+
+* Retrying a pipeline
+
+  ```
+  glpl [PROJECT_NAME] -r [PIPELINE_ID]
+  ```

--- a/bin/glpl
+++ b/bin/glpl
@@ -28,9 +28,20 @@ OptionParser.new do |opts|
   opts.on("-p", "--pipeline ID", Integer, "Pipeline ID") do |pipeline_id|
     options[:pipeline_id] = pipeline_id
   end
+
+  opts.on("-r", "--retry ID", "Retry a given pipeline") do |pipeline_id|
+    options[:pipeline_id] = pipeline_id
+    options[:retry] = true
+  end
 end.parse!
 
 glpl = GLPL.new(private_token)
+
+if options.key?(:retry) then
+  glpl.retry(project_id, options[:pipeline_id])
+  printf("Sucessfully retried Pipeline#%s.\n", options[:pipeline_id])
+  exit
+end
 
 if options.key?(:pipeline_id) then
   for job in glpl.jobs(project_id, options[:pipeline_id]) do

--- a/glpl.gemspec
+++ b/glpl.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = "glpl"
-  spec.version     = "0.0.2"
+  spec.version     = "0.1.0"
   spec.date        = Time.now.strftime("%Y-%m-%d")
   spec.summary     = "Gitlab Pipelines on your command line."
   spec.description = "Gitlab Pipelines on your command line."

--- a/lib/glpl.rb
+++ b/lib/glpl.rb
@@ -30,6 +30,14 @@ class GLPL
     request("/#{project_id}/pipelines/#{pipeline_id}/jobs", :get).map { |data| GLPL::Job.new(data) }
   end
 
+  # Retries a pipeline.
+  # Params:
+  # +project_id+:: +Integer+ Gitlab's project ID.
+  # +pipeline_id+:: +Integer+ The pipeline's ID.
+  def retry(project_id, pipeline_id)
+    GLPL::Pipeline.new(request("/#{project_id}/pipelines/#{pipeline_id}/retry", :post))
+  end
+
   # Makes an HTTP Requests to Gitlab's API and returns the response as JSON.
   # Params:
   # +endpoint+:: +String+ which represents the API's endpoint to be contacted.


### PR DESCRIPTION
This Pull Request updates both the gem and the command line tool with the ability to retry pipelines, mostly used if they failed.

On the gem you can now find the `GLPL.retry` method which allows you to retry a given pipeline for a given project. Check the method's documentation for more details.

Regarding the command line tool, you'll now be able to run:

```
$ glpl [PROJECT_NAME] -r [PIPELINE_ID] 
```

Whic will retry a given pipeline on Gitlab.