### PR TITLE
Create cancel feature

### DIFF
--- a/bin/glpl
+++ b/bin/glpl
@@ -41,7 +41,13 @@ OptionParser.new do |opts|
 
   opts.on("-r", "--retry ID", "Retry a given pipeline") do |pipeline_id|
     glpl.retry(project_id, pipeline_id)
-    printf("Sucessfully retried Pipeline#%s.\n", options[:pipeline_id])
+    printf("Sucessfully retried Pipeline#%s.\n", pipeline_id)
+    exit
+  end
+
+  opts.on("-c", "--cancel ID", "Cancel a given pipeline") do |pipeline_id|
+    glpl.cancel(project_id, pipeline_id)
+    printf("Sucessfully canceled Pipeline#%s.\n", pipeline_id)
     exit
   end
 end.parse!

--- a/lib/glpl.rb
+++ b/lib/glpl.rb
@@ -38,6 +38,15 @@ class GLPL
     GLPL::Pipeline.new(request("/#{project_id}/pipelines/#{pipeline_id}/retry", :post))
   end
 
+  # Cancels a pipeline.
+  #
+  # Params:
+  # +project_id+:: +Integer+ Gitlab's project ID.
+  # +pipeline_id+:: +Integer+ The pipeline's ID.
+  def cancel(project_id, pipeline_id)
+    GLPL::Pipeline.new(request("/#{project_id}/pipelines/#{pipeline_id}/cancel", :post))
+  end
+
   # Makes an HTTP Requests to Gitlab's API and returns the response as JSON.
   # Params:
   # +endpoint+:: +String+ which represents the API's endpoint to be contacted.


### PR DESCRIPTION
This Merge Request adds the ability to cancel running pipelines.

The `GLPL` class has been updated with a `cancel` method which cancels the provided pipeline in the provided project.

With this changes the CLI has also been updated in order to simply be able to run:

```shell
▲ glpl [PROJECT_NAME] -c [PIPELINE_ID]
```